### PR TITLE
Fix for install.sh issues mentioned in #15

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -13,7 +13,7 @@ delete_line () {
 
 # parse /boot/config.txt and append i2c config if missing
 i2c_boot_config () {
-  local config='/boot/config.txt'; local line; local i2c_reconfig='false'; local i2c_reconfig_line
+  local config='/boot/config.txt'; local line; local i2c_reconfig; local i2c_reconfig_line
   while read -r line; do
     if [[ "$line" =~ ^dtparam=i2c(_arm){0,1}(=on|=1){0,1}$ ]]; then
       i2c_reconfig='false'; break
@@ -27,7 +27,7 @@ i2c_boot_config () {
     # delete i2c=off config and append i2c=on config
     delete_line "$i2c_reconfig_line" "$config"
     echo "dtparam=i2c" | tee -a "$config" > /dev/null
-  elif [[ "$i2c_reconfig" == 'false' ]]; then
+  elif [[ -z "$i2c_reconfig" ]]; then
     # backup config.txt
     cp "$config" "$config".backup
     # i2c config not found, append to file
@@ -43,7 +43,7 @@ line_to_list () {
   while read -r line; do
     if [[ -n "$line" && ! "$line" =~ ^\# ]]; then list+=("$line"); fi
   done < "$file"
-  if [[ -z "$list" ]]; then return 1; fi
+  if [[ -z "${list[@]}" ]]; then return 1; fi
 }
 
 # takes path to an old modules file as first argument ($1) and a new file as second arg ($2).

--- a/install.sh
+++ b/install.sh
@@ -104,8 +104,8 @@ else
   echo "There was an error while updating /etc/modules. i2c might not work."
 fi
 #check raspi-blacklist.conf
-if modules /etc/moddprobe.d/raspi-blacklist.conf "$config_dir"/raspi-blacklist.conf; then
-  echo "Updated required modules in /etc/moddprobe.d/raspi-blacklist.conf."
+if modules /etc/modprobe.d/raspi-blacklist.conf "$config_dir"/raspi-blacklist.conf; then
+  echo "Updated required modules in /etc/modprobe.d/raspi-blacklist.conf."
 fi
 
 echo "Enabling i2c on boot."

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,95 @@
 #!/bin/bash
+
+apt_install () {
+  apt update && apt install python-smbus -y
+}
+
+# find line that contains $1 from file $2 and delete it permanently
+delete_line () {
+  sed -i '/'"$1"'/d' "$2" 
+}
+
+# parse /boot/config.txt and append i2c config if missing
+i2c_boot_config () {
+  local line; local i2c_config='false'; local config='/boot/config.txt'
+  while read -r line; do
+    if [[ "$line" =~ ^dtparam=i2c(_arm){0,1}(=on|=1){0,1}$ ]]; then
+      i2c_config='true'; break
+    elif [[ "$line" =~ ^dtparam=i2c(_arm){0,1}(=off|=0){1}$ ]]; then
+      # backup config.txt
+      cp "$config" "$config".backup
+      # delete i2c=off config and append i2c=on config
+      delete_line "$line" "$config"
+      echo "dtparam=i2c" | tee -a "$config" > /dev/null
+      echo "append new line"
+      echo "break 3"; i2c_config='true'
+      break
+    fi
+  done < "$config"
+  if [[ "$i2c_config" == 'false' ]]; then
+    # backup config.txt
+    cp "$config" "$config".backup
+    # i2c config not found, append to file
+    echo "dtparam=i2c" | tee -a "$config" > /dev/null
+  fi
+}
+
+# takes path to a file as first argument ($1) and creates a global 
+# $list array with non-empty and non-commented out lines as elements
+line_to_list () {
+  if [[ -z "$1" || ! -f "$1" ]]; then return 1; fi
+  unset list; list=(); local file="$1"; local line
+  while read -r line; do
+    if [[ -n "$line" && ! "$line" =~ ^\# ]]; then list+=("$line"); fi
+  done < "$file"
+  if [[ -z "$list" ]]; then return 1; fi
+}
+
+modules_load () {
+  #check /etc/modules
+  if [[ ! -f /etc/modules || -z $(cat /etc/modules) ]]; then
+    cp "$config_dir"/modules /etc/
+  else
+    if line_to_list "$config_dir"/modules; then
+      for mod in "${list[@]}"; do
+        if [[ ! "$(cat /etc/modules)" =~ $mod ]]; then
+          echo "$mod" | tee -a /etc/modules > /dev/null
+        fi
+      done
+    fi
+  fi
+}
+
+modules_blacklist () {
+  #check /etc/moddprobe.d/raspi-blacklist.conf
+  if [[ ! -f /etc/modprobe.d/raspi-blacklist.conf || -z $(cat /etc/modprobe.d/raspi-blacklist.conf) ]]; then
+    cp "$config_dir"/raspi-blacklist.conf /etc/modprobe.d/
+  else
+    if line_to_list "$config_dir"/raspi-blacklist.conf; then
+      for blacklisted in "${list[@]}"; do
+        if [[ ! "$(cat /etc/modprobe.d/raspi-blacklist.conf)" =~ $blacklisted ]]; then
+          echo "$blacklisted" | tee -a /etc/modprobe.d/raspi-blacklist.conf > /dev/null
+        fi
+      done
+    fi
+  fi
+}
+
+rpi_revision () {
+  revision=$(python -c "import RPi.GPIO as GPIO; print GPIO.RPI_REVISION")
+  if [[ "$revision" -eq 1 ]]; then
+    echo "I2C Pins detected as 0"
+    cp "$config_dir"/i2c_lib_0.py ./i2c_lib.py
+  else
+    echo "I2C Pins detected as 1"
+    cp "$config_dir"/i2c_lib_1.py ./i2c_lib.py
+  fi
+}
+
+
+##############
+# Start script
+
 if [ "$(id -u)" != "0" ]; then
   echo "Please re-run as sudo."
   exit 1
@@ -6,24 +97,21 @@ fi
 
 echo "Automated Installer Program For I2C LCD Screens"
 echo "Installer by Ryanteck LTD. Cloned and tweaked by Matthew Timmons-Brown for The Raspberry Pi Guy YouTube tutorial"
-echo "Updating APT & Installing python-smbus, if password is asked by sudo please enter it"
-apt-get update
-apt-get install python-smbus -y
-echo "Should now be installed, now checking revision"
-revision=$(python -c "import RPi.GPIO as GPIO; print GPIO.RPI_REVISION")
 
-if [ "$revision" = "1" ]; then
-  echo "I2C Pins detected as 0"
-  cp installConfigs/i2c_lib_0.py ./i2c_lib.py
-else
-  echo "I2C Pins detected as 1"
-  cp installConfigs/i2c_lib_1.py ./i2c_lib.py
-fi
-echo "I2C Library setup for this revision of Raspberry Pi, if you change revision a modification will be required to i2c_lib.py"
-echo "Now overwriting modules & blacklist. This will enable i2c Pins"
-cp installConfigs/modules /etc/
-cp installConfigs/raspi-blacklist.conf /etc/modprobe.d/
-printf "dtparam=i2c_arm=1\n" >> /boot/config.txt
+echo "Updating APT & Installing python-smbus, if password is asked by sudo please enter it"
+apt-install
+echo "Should now be installed, now checking revision"
+# global directory for the config files
+config_dir="installConfigs"
+rpi_revision
+echo "I2C Library setup for this revision of Raspberry Pi. If you change revision, a modification will be required to i2c_lib.py"
+
+echo "Checking modules & blacklist. This will enable i2c Pins"
+modules_load
+modules_blacklist
+
+echo "Enabling i2c on boot"
+i2c_boot_config
 
 echo "Should be now all finished. Please press any key to now reboot. After rebooting run"
 echo "'sudo python demo_lcd.py' from this directory"

--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,7 @@ apt-get install python-smbus -y
 echo "Should now be installed, now checking revision"
 revision=$(python -c "import RPi.GPIO as GPIO; print GPIO.RPI_REVISION")
 
-if [ $revision = "1" ]; then
+if [ "$revision" = "1" ]; then
   echo "I2C Pins detected as 0"
   cp installConfigs/i2c_lib_0.py ./i2c_lib.py
 else

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 if [ "$(id -u)" != "0" ]; then
-	echo "Please re-run as sudo."
-	exit 1
+  echo "Please re-run as sudo."
+  exit 1
 fi
 
 echo "Automated Installer Program For I2C LCD Screens"
@@ -12,20 +12,18 @@ apt-get install python-smbus -y
 echo "Should now be installed, now checking revision"
 revision=`python -c "import RPi.GPIO as GPIO; print GPIO.RPI_REVISION"`
 
-if [ $revision = "1" ]
-then
-echo "I2C Pins detected as 0"
-cp installConfigs/i2c_lib_0.py ./i2c_lib.py
+if [ $revision = "1" ]; then
+  echo "I2C Pins detected as 0"
+  cp installConfigs/i2c_lib_0.py ./i2c_lib.py
 else
-echo "I2C Pins detected as 1"
-cp installConfigs/i2c_lib_1.py ./i2c_lib.py
+  echo "I2C Pins detected as 1"
+  cp installConfigs/i2c_lib_1.py ./i2c_lib.py
 fi
 echo "I2C Library setup for this revision of Raspberry Pi, if you change revision a modification will be required to i2c_lib.py"
 echo "Now overwriting modules & blacklist. This will enable i2c Pins"
 cp installConfigs/modules /etc/
 cp installConfigs/raspi-blacklist.conf /etc/modprobe.d/
 printf "dtparam=i2c_arm=1\n" >> /boot/config.txt
-
 
 echo "Should be now all finished. Please press any key to now reboot. After rebooting run"
 echo "'sudo python demo_lcd.py' from this directory"

--- a/install.sh
+++ b/install.sh
@@ -10,7 +10,7 @@ echo "Updating APT & Installing python-smbus, if password is asked by sudo pleas
 apt-get update
 apt-get install python-smbus -y
 echo "Should now be installed, now checking revision"
-revision=`python -c "import RPi.GPIO as GPIO; print GPIO.RPI_REVISION"`
+revision=$(python -c "import RPi.GPIO as GPIO; print GPIO.RPI_REVISION")
 
 if [ $revision = "1" ]; then
   echo "I2C Pins detected as 0"

--- a/install.sh
+++ b/install.sh
@@ -92,7 +92,7 @@ apt_install
 echo "Should now be installed, now checking revision."
 
 # global directory for the config files
-config_dir="installConfigs."
+config_dir="installConfigs"
 rpi_revision
 echo "I2C Library setup for this revision of Raspberry Pi. If you change revision, a modification will be required to i2c_lib.py."
 

--- a/install.sh
+++ b/install.sh
@@ -21,9 +21,7 @@ i2c_boot_config () {
       # delete i2c=off config and append i2c=on config
       delete_line "$line" "$config"
       echo "dtparam=i2c" | tee -a "$config" > /dev/null
-      echo "append new line"
-      echo "break 3"; i2c_config='true'
-      break
+      i2c_config='true'; break
     fi
   done < "$config"
   if [[ "$i2c_config" == 'false' ]]; then

--- a/install.sh
+++ b/install.sh
@@ -98,9 +98,15 @@ echo "I2C Library setup for this revision of Raspberry Pi. If you change revisio
 
 echo "Checking modules & blacklist. This will enable i2c Pins."
 #check modules
-modules /etc/modules "$config_dir"/modules
+if modules /etc/modules "$config_dir"/modules; then
+  echo "Updated required modules in /etc/modules."
+else
+  echo "There was an error while updating /etc/modules. i2c might not work."
+fi
 #check raspi-blacklist.conf
-modules /etc/moddprobe.d/raspi-blacklist.conf "$config_dir"/raspi-blacklist.conf
+if modules /etc/moddprobe.d/raspi-blacklist.conf "$config_dir"/raspi-blacklist.conf; then
+  echo "Updated required modules in /etc/moddprobe.d/raspi-blacklist.conf."
+fi
 
 echo "Enabling i2c on boot."
 i2c_boot_config


### PR DESCRIPTION
This fixes #15 as follows:

* Script uses two spaces for indentation
* Fixed overwriting of the `/etc/modules` file: the script will now parse and append only missing modules
* Fixed overwriting of the `/etc/modprobe.d/raspi-blacklist.conf` file: the script will now parse and append only missing blacklisted modules
* Fixed appending `dtparam=i2c_arm=1` to `/boot/config.txt`: the script will now check if `i2c` has been explicitly enabled or disabled and append to the `config.txt` file if missing.  In addition, `dtparam=i2c` is used as shortcut for enabling `i2c`, per the [device tree documentation](https://www.raspberrypi.org/documentation/configuration/device-tree.md)

In addition, this PR includes the following changes:
* The structure of the script has been somewhat modified in order to better organize the additional functions to parse existing files and to separate the content according to its function.  
* Almost all previous `echo` messages have been preserved.  However, a few have been added or edited to better reflect the modifications made to the script.
* Minor fixes: Fixed the use of legacy backtick substition command in the `python` code to read `gpio.rpi_revision` and missing double quotations.

The changes **do not introduce anything new** to the script that requires new instructions to users or compatibility issues.  The requirements to run this version of the `install.sh` are the same as before.

The changes have been tested on the following hardware and software:
* Raspberry Pi 3B
* OS: Raspbian GNU/Linux 10 (buster)
* Bash: GNU bash, version 5.0.3(1)-release
* `i2cdetect -l`:
```
i2c-1	i2c       	bcm2835 (i2c@7e804000)          	I2C adapter
```
* `i2cdetect -y 1`
```
     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
00:          -- -- -- -- -- -- -- -- -- -- -- -- -- 
10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
20: -- -- -- -- -- -- -- 27 -- -- -- -- -- -- -- -- 
30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
40: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
70: -- -- -- -- -- -- -- --                         
```

Let me know if you have any questions and of course, feel free to edit.