### PR TITLE
Hotfix for i2c_dev import issue when using Python3+

### DIFF
--- a/drivers/__init__.py
+++ b/drivers/__init__.py
@@ -1,1 +1,1 @@
-from i2c_dev import Lcd
+from .i2c_dev import Lcd


### PR DESCRIPTION
This fixes #21 as follows:
* It adds a relative path to `i2c_dev` in the `__init__.py` file that allows to initialize `Lcd` when running Python 3+.  This change does not affect Python 2.7.

As a side note, `setup.sh` only installs the `smbus` package for Python2.  Users trying to run code with Python 3+ will have to manually install `python3-smbus`.  To avoid this issue, you can simply add the latter pkg to the `apt install` list in `setup.sh`.  (Didn't want to do that here because it's not directly related to issue #21.)