### PR TITLE
Hotfix for i2c device addr autodetection in i2c_dev

### DIFF
--- a/drivers/i2c_dev.py
+++ b/drivers/i2c_dev.py
@@ -99,7 +99,8 @@ class I2CDevice:
 
 class Lcd:
     def __init__(self, addr=None):
-        self.lcd = I2CDevice(addr=addr, addr_default=0x27)
+        self.addr = addr
+        self.lcd = I2CDevice(addr=self.addr, addr_default=0x27)
         self.lcd_write(0x03)
         self.lcd_write(0x03)
         self.lcd_write(0x03)

--- a/drivers/i2c_dev.py
+++ b/drivers/i2c_dev.py
@@ -61,7 +61,7 @@ class I2CDevice:
             # try autodetect address, else use default if provided
             try:
                 self.addr = int('0x{}'.format(
-                    findall("[0-9a-z]{2}(?!:)", check_output(['/usr/sbin/i2cdetect', '-y', BUS_NUMBER]))[0]), base=16) \
+                    findall("[0-9a-z]{2}(?!:)", check_output(['/usr/sbin/i2cdetect', '-y', str(BUS_NUMBER)]))[0]), base=16) \
                     if exists('/usr/sbin/i2cdetect') else addr_default
             except:
                 self.addr = addr_default

--- a/drivers/i2c_dev.py
+++ b/drivers/i2c_dev.py
@@ -98,8 +98,8 @@ class I2CDevice:
 
 
 class Lcd:
-    def __init__(self):
-        self.lcd = I2CDevice(addr_default=0x27)
+    def __init__(self, addr=None):
+        self.lcd = I2CDevice(addr=addr, addr_default=0x27)
         self.lcd_write(0x03)
         self.lcd_write(0x03)
         self.lcd_write(0x03)


### PR DESCRIPTION
In #26, it was noticed that there was an error with the current implementation of the `addr` autodetection.  Specifically, in `check_output()` (https://github.com/the-raspberry-pi-guy/lcd/blob/master/drivers/i2c_dev.py#L64), args must be strings but `BUS_NUMBER` was an integer. This causes an error and set `self.addr = addr_default` in the `I2CDevice` class, which was set to the hex literal `0x27`.  Wrapping `BUS_NUMBER` in a string function (`str(BUS_NUMBER)`) solves the issue.

In addition, it was noticed that the `Lcd()` class was missing the `addr` attribute, as pointed out in a previous PR (#20). (Think the reference was actually about the `I2CDevice` class.)  This was also fixed to allow users to load their lcd using a custom i2c `addr` (`display = drivers.Lcd(addr=0x3f)`), instead of relying on autodetection or the default one.

All demos are running as intended after applying the changes in this PR. Tested with:
- Python: `2.7.16`
- Raspberry model: `RPi 3B`
- OS: `Raspbian GNU/Linux 10 (buster)`
- Kernel: `5.10.17-v7+`
- Architecture: `arm`

If you or someone else want to test before merging, please clone from my repo's `hotfix/i2c_addr` branch:
- https://github.com/cgomesu/rpi-lcd/tree/hotfix/i2c_addr