### PR TITLE
addr i2c detection, bytes is not str Python 3.x compatibility

### DIFF
--- a/drivers/i2c_dev.py
+++ b/drivers/i2c_dev.py
@@ -61,7 +61,7 @@ class I2CDevice:
             # try autodetect address, else use default if provided
             try:
                 self.addr = int('0x{}'.format(
-                    findall("[0-9a-z]{2}(?!:)", check_output(['/usr/sbin/i2cdetect', '-y', str(BUS_NUMBER)]))[0]), base=16) \
+                    findall("[0-9a-z]{2}(?!:)", check_output(['/usr/sbin/i2cdetect', '-y', str(BUS_NUMBER)]).decode())[0]), base=16) \
                     if exists('/usr/sbin/i2cdetect') else addr_default
             except:
                 self.addr = addr_default


### PR DESCRIPTION
https://github.com/the-raspberry-pi-guy/lcd/issues/33