### PR TITLE
FIX BACKLIGHT  -fix #69 -redo PR #70 

### DIFF
--- a/drivers/i2c_dev.py
+++ b/drivers/i2c_dev.py
@@ -50,6 +50,7 @@ LCD_5x8DOTS = 0x00
 # flags for backlight control
 LCD_BACKLIGHT = 0x08
 LCD_NOBACKLIGHT = 0x00
+SESSION_STATE_BACKLIGHT = ''
 
 En = 0b00000100  # Enable bit
 Rw = 0b00000010  # Read/Write bit
@@ -113,13 +114,21 @@ class Lcd:
 
     # clocks EN to latch command
     def lcd_strobe(self, data):
-        self.lcd.write_cmd(data | En | LCD_BACKLIGHT)
+        if SESSION_STATE_BACKLIGHT == 0:
+            LCD = LCD_NOBACKLIGHT
+        else:
+            LCD = LCD_BACKLIGHT
+        self.lcd.write_cmd(data | En | LCD)
         sleep(.0005)
-        self.lcd.write_cmd(((data & ~En) | LCD_BACKLIGHT))
+        self.lcd.write_cmd(((data & ~En) | LCD))
         sleep(.0001)
 
     def lcd_write_four_bits(self, data):
-        self.lcd.write_cmd(data | LCD_BACKLIGHT)
+        if SESSION_STATE_BACKLIGHT == 0:
+            LCD = LCD_NOBACKLIGHT
+        else:
+            LCD = LCD_BACKLIGHT
+        self.lcd.write_cmd(data | LCD)
         self.lcd_strobe(data)
 
     # write a command to lcd
@@ -140,7 +149,7 @@ class Lcd:
         for char in string:
             self.lcd_write(ord(char), Rs)
 
-    # put extended string function. Extended string may contain placeholder like {0xFF} for 
+    # put extended string function. Extended string may contain placeholder like {0xFF} for
     # displaying the particular symbol from the symbol table
     def lcd_display_extended_string(self, string, line):
         if line == 1:
@@ -170,11 +179,14 @@ class Lcd:
     # backlight control (on/off)
     # options: lcd_backlight(1) = ON, lcd_backlight(0) = OFF
     def lcd_backlight(self, state):
+        global SESSION_STATE_BACKLIGHT
         if state == 1:
             self.lcd.write_cmd(LCD_BACKLIGHT)
         elif state == 0:
             self.lcd.write_cmd(LCD_NOBACKLIGHT)
 
+        if state == 1 or state == 0:  # Save backlight settings
+            SESSION_STATE_BACKLIGHT = state
 class CustomCharacters:
     def __init__(self, lcd):
         self.lcd = lcd
@@ -251,9 +263,9 @@ class CustomCharacters:
                             "10001",
                             "11111"]
 
-    # load custom character data to CG RAM for later use in extended string. Data for  
-    # characters is hold in file custom_characters.txt in the same folder as i2c_dev.py 
-    # file. These custom characters can be used in printing of extended string with a 
+    # load custom character data to CG RAM for later use in extended string. Data for
+    # characters is hold in file custom_characters.txt in the same folder as i2c_dev.py
+    # file. These custom characters can be used in printing of extended string with a
     # placeholder with desired character codes: 1st - {0x00}, 2nd - {0x01}, 3rd - {0x02},
     # 4th - {0x03}, 5th - {0x04}, 6th - {0x05}, 7th - {0x06} and 8th - {0x07}.
     def load_custom_characters_data(self):


### PR DESCRIPTION
The BACKLIGHT function is very useful but it has a bug. Each update of the LCD screen resets the BACKLIGHT value to ON. So we cannot have a permanent display without backlight. I fixed the problem. The default display is with backlight. You can configure this with lcd_backlight as before. If you do lcd_blacklight(1) then it will be lit. If it is 0 it will be turned off. I added security, if you put any number other than 1 or 0 then it will necessarily be on.

Here is the PR with only one commit to fix #69 Issue
This is a redo of closed #70 PR

I tested with all the other demos as suggested @cgomesu. There is no problem. If I have omitted any details, I will do the necessary